### PR TITLE
Allow matrix input and don't strip names

### DIFF
--- a/R/odds.dec2hk.R
+++ b/R/odds.dec2hk.R
@@ -10,6 +10,7 @@
 #' odds.dec2hk(c(1.93,2.05))
 odds.dec2hk <- function (x) {
   hk <- rep(NA_real_, length(x))
+  names(hk) <- names(x)
   hk[which(x > 1)] <- x[which(x > 1)] - 1
   hk
 }

--- a/R/odds.dec2hk.R
+++ b/R/odds.dec2hk.R
@@ -9,9 +9,8 @@
 #' @examples
 #' odds.dec2hk(c(1.93,2.05))
 odds.dec2hk <- function (x) {
-  hk <- rep(NA_real_, length(x))
-  dim(hk) <- dim(x)
-  names(hk) <- names(x)
+  hk <- x
+  hk[] <- NA_real_
   hk[which(x > 1)] <- x[which(x > 1)] - 1
   hk
 }

--- a/R/odds.dec2hk.R
+++ b/R/odds.dec2hk.R
@@ -10,6 +10,7 @@
 #' odds.dec2hk(c(1.93,2.05))
 odds.dec2hk <- function (x) {
   hk <- rep(NA_real_, length(x))
+  dim(hk) <- dim(x)
   names(hk) <- names(x)
   hk[which(x > 1)] <- x[which(x > 1)] - 1
   hk

--- a/R/odds.dec2indo.R
+++ b/R/odds.dec2indo.R
@@ -10,6 +10,7 @@
 #' odds.dec2indo(c(1.93,2.05))
 odds.dec2indo <- function (x) {
   indo <- rep(NA_real_, length(x))
+  names(indo) <- names(x)
   indo[which(x > 1)] <- odds.dec2us(x[which(x > 1)]) / 100
   indo
 }

--- a/R/odds.dec2indo.R
+++ b/R/odds.dec2indo.R
@@ -10,6 +10,7 @@
 #' odds.dec2indo(c(1.93,2.05))
 odds.dec2indo <- function (x) {
   indo <- rep(NA_real_, length(x))
+  dim(indo) <- dim(x)
   names(indo) <- names(x)
   indo[which(x > 1)] <- odds.dec2us(x[which(x > 1)]) / 100
   indo

--- a/R/odds.dec2indo.R
+++ b/R/odds.dec2indo.R
@@ -9,9 +9,8 @@
 #' @examples
 #' odds.dec2indo(c(1.93,2.05))
 odds.dec2indo <- function (x) {
-  indo <- rep(NA_real_, length(x))
-  dim(indo) <- dim(x)
-  names(indo) <- names(x)
+  indo <- x
+  indo[] <- NA_real_
   indo[which(x > 1)] <- odds.dec2us(x[which(x > 1)]) / 100
   indo
 }

--- a/R/odds.dec2malay.R
+++ b/R/odds.dec2malay.R
@@ -10,6 +10,7 @@
 #' odds.dec2malay(c(1.93,2.05))
 odds.dec2malay <- function (x) {
   malay <- rep(NA_real_, length(x))
+  dim(malay) <- dim(x)
   names(malay) <- names(x)
   malay[which(x > 1)] <- odds.us2malay(odds.dec2us(x[which(x > 1)]))
   malay

--- a/R/odds.dec2malay.R
+++ b/R/odds.dec2malay.R
@@ -9,9 +9,8 @@
 #' @examples
 #' odds.dec2malay(c(1.93,2.05))
 odds.dec2malay <- function (x) {
-  malay <- rep(NA_real_, length(x))
-  dim(malay) <- dim(x)
-  names(malay) <- names(x)
+  malay <- x
+  malay[] <- NA_real_
   malay[which(x > 1)] <- odds.us2malay(odds.dec2us(x[which(x > 1)]))
   malay
 }

--- a/R/odds.dec2malay.R
+++ b/R/odds.dec2malay.R
@@ -10,6 +10,7 @@
 #' odds.dec2malay(c(1.93,2.05))
 odds.dec2malay <- function (x) {
   malay <- rep(NA_real_, length(x))
+  names(malay) <- names(x)
   malay[which(x > 1)] <- odds.us2malay(odds.dec2us(x[which(x > 1)]))
   malay
 }

--- a/R/odds.dec2prob.R
+++ b/R/odds.dec2prob.R
@@ -10,6 +10,7 @@
 #' odds.dec2prob(c(1.93,2.05))
 odds.dec2prob <- function (x) {
   prob <- rep(NA_real_, length(x))
+  dim(prob) <- dim(x)
   names(prob) <- names(x)
   prob[which(x > 1)] <- 1 / x[which(x > 1)]
   prob

--- a/R/odds.dec2prob.R
+++ b/R/odds.dec2prob.R
@@ -10,6 +10,7 @@
 #' odds.dec2prob(c(1.93,2.05))
 odds.dec2prob <- function (x) {
   prob <- rep(NA_real_, length(x))
+  names(prob) <- names(x)
   prob[which(x > 1)] <- 1 / x[which(x > 1)]
   prob
 }

--- a/R/odds.dec2prob.R
+++ b/R/odds.dec2prob.R
@@ -9,9 +9,8 @@
 #' @examples
 #' odds.dec2prob(c(1.93,2.05))
 odds.dec2prob <- function (x) {
-  prob <- rep(NA_real_, length(x))
-  dim(prob) <- dim(x)
-  names(prob) <- names(x)
+  prob <- x
+  prob[] <- NA_real_
   prob[which(x > 1)] <- 1 / x[which(x > 1)]
   prob
 }

--- a/R/odds.dec2us.R
+++ b/R/odds.dec2us.R
@@ -10,6 +10,7 @@
 #' odds.dec2us(c(1.93,2.05))
 odds.dec2us <- function (x) {
   us <- rep(NA_real_, length(x))
+  names(us) <- names(x)
   us[which(x > 1)] <- -100 / (x[which(x > 1)] - 1)
   us[which(x > 2)] <- 100 * (x[which(x > 2)] - 1)
   us

--- a/R/odds.dec2us.R
+++ b/R/odds.dec2us.R
@@ -9,9 +9,8 @@
 #' @examples
 #' odds.dec2us(c(1.93,2.05))
 odds.dec2us <- function (x) {
-  us <- rep(NA_real_, length(x))
-  dim(us) <- dim(x)
-  names(us) <- names(x)
+  us <- x
+  us[] <- NA_real_  
   us[which(x > 1)] <- -100 / (x[which(x > 1)] - 1)
   us[which(x > 2)] <- 100 * (x[which(x > 2)] - 1)
   us

--- a/R/odds.dec2us.R
+++ b/R/odds.dec2us.R
@@ -10,6 +10,7 @@
 #' odds.dec2us(c(1.93,2.05))
 odds.dec2us <- function (x) {
   us <- rep(NA_real_, length(x))
+  dim(us) <- dim(x)
   names(us) <- names(x)
   us[which(x > 1)] <- -100 / (x[which(x > 1)] - 1)
   us[which(x > 2)] <- 100 * (x[which(x > 2)] - 1)

--- a/R/odds.hk2dec.R
+++ b/R/odds.hk2dec.R
@@ -10,6 +10,7 @@
 #' odds.hk2dec(c(1.93,0.05))
 odds.hk2dec <- function (x) {
   dec <- rep(NA_real_, length(x))
+  dim(dec) <- dim(x)
   names(dec) <- names(x)
   dec[which(x > 0)] <- x[which(x > 0)] + 1
   dec

--- a/R/odds.hk2dec.R
+++ b/R/odds.hk2dec.R
@@ -9,9 +9,8 @@
 #' @examples
 #' odds.hk2dec(c(1.93,0.05))
 odds.hk2dec <- function (x) {
-  dec <- rep(NA_real_, length(x))
-  dim(dec) <- dim(x)
-  names(dec) <- names(x)
+  dec <- x
+  dec[] <- NA_real_
   dec[which(x > 0)] <- x[which(x > 0)] + 1
   dec
 }

--- a/R/odds.hk2dec.R
+++ b/R/odds.hk2dec.R
@@ -10,6 +10,7 @@
 #' odds.hk2dec(c(1.93,0.05))
 odds.hk2dec <- function (x) {
   dec <- rep(NA_real_, length(x))
+  names(dec) <- names(x)
   dec[which(x > 0)] <- x[which(x > 0)] + 1
   dec
 }

--- a/R/odds.hk2indo.R
+++ b/R/odds.hk2indo.R
@@ -10,6 +10,7 @@
 #' odds.hk2indo(c(1.93,0.05))
 odds.hk2indo <- function (x) {
   indo <- rep(NA_real_, length(x))
+  names(indo) <- names(x)
   indo[which(x > 0)] <- odds.hk2us(x[which(x > 0)]) / 100
   indo
 }

--- a/R/odds.hk2indo.R
+++ b/R/odds.hk2indo.R
@@ -9,9 +9,8 @@
 #' @examples
 #' odds.hk2indo(c(1.93,0.05))
 odds.hk2indo <- function (x) {
-  indo <- rep(NA_real_, length(x))
-  dim(indo) <- dim(x)
-  names(indo) <- names(x)
+  indo <- x
+  indo[] <- NA_real_
   indo[which(x > 0)] <- odds.hk2us(x[which(x > 0)]) / 100
   indo
 }

--- a/R/odds.hk2indo.R
+++ b/R/odds.hk2indo.R
@@ -10,6 +10,7 @@
 #' odds.hk2indo(c(1.93,0.05))
 odds.hk2indo <- function (x) {
   indo <- rep(NA_real_, length(x))
+  dim(indo) <- dim(x)
   names(indo) <- names(x)
   indo[which(x > 0)] <- odds.hk2us(x[which(x > 0)]) / 100
   indo

--- a/R/odds.hk2malay.R
+++ b/R/odds.hk2malay.R
@@ -10,6 +10,7 @@
 #' odds.hk2malay(c(1.93,0.05))
 odds.hk2malay <- function (x) {
   malay <- rep(NA_real_, length(x))
+  names(malay) <- names(x)
   malay[which(x > 0)] <- -100 / odds.hk2us(x[which(x > 0)])
   malay
 }

--- a/R/odds.hk2malay.R
+++ b/R/odds.hk2malay.R
@@ -10,6 +10,7 @@
 #' odds.hk2malay(c(1.93,0.05))
 odds.hk2malay <- function (x) {
   malay <- rep(NA_real_, length(x))
+  dim(malay) <- dim(x)
   names(malay) <- names(x)
   malay[which(x > 0)] <- -100 / odds.hk2us(x[which(x > 0)])
   malay

--- a/R/odds.hk2malay.R
+++ b/R/odds.hk2malay.R
@@ -9,9 +9,8 @@
 #' @examples
 #' odds.hk2malay(c(1.93,0.05))
 odds.hk2malay <- function (x) {
-  malay <- rep(NA_real_, length(x))
-  dim(malay) <- dim(x)
-  names(malay) <- names(x)
+  malay <- x
+  malay[] <- NA_real_
   malay[which(x > 0)] <- -100 / odds.hk2us(x[which(x > 0)])
   malay
 }

--- a/R/odds.hk2prob.R
+++ b/R/odds.hk2prob.R
@@ -10,6 +10,7 @@
 #' odds.hk2us(c(1.93,0.05))
 odds.hk2prob<- function (x) {
   prob <- rep(NA_real_, length(x))
+  dim(prob) <- dim(x)
   names(prob) <- names(x)
   prob[which(x > 0)] <- 1 / (x[which(x > 0)] + 1)
   prob

--- a/R/odds.hk2prob.R
+++ b/R/odds.hk2prob.R
@@ -9,9 +9,8 @@
 #' @examples
 #' odds.hk2us(c(1.93,0.05))
 odds.hk2prob<- function (x) {
-  prob <- rep(NA_real_, length(x))
-  dim(prob) <- dim(x)
-  names(prob) <- names(x)
+  prob <- x
+  prob[] <- NA_real_
   prob[which(x > 0)] <- 1 / (x[which(x > 0)] + 1)
   prob
 }

--- a/R/odds.hk2prob.R
+++ b/R/odds.hk2prob.R
@@ -10,6 +10,7 @@
 #' odds.hk2us(c(1.93,0.05))
 odds.hk2prob<- function (x) {
   prob <- rep(NA_real_, length(x))
+  names(prob) <- names(x)
   prob[which(x > 0)] <- 1 / (x[which(x > 0)] + 1)
   prob
 }

--- a/R/odds.hk2us.R
+++ b/R/odds.hk2us.R
@@ -10,6 +10,7 @@
 #' odds.hk2us(c(1.93,0.05))
 odds.hk2us <- function (x) {
   us <- rep(NA_real_, length(x))
+  names(us) <- names(x)
   us[which(x > 0)] <- -100 / x[which(x > 0)]
   us[which(x > 1)] <- 100 * x[which(x > 1)]
   us

--- a/R/odds.hk2us.R
+++ b/R/odds.hk2us.R
@@ -10,6 +10,7 @@
 #' odds.hk2us(c(1.93,0.05))
 odds.hk2us <- function (x) {
   us <- rep(NA_real_, length(x))
+  dim(us) <- dim(x)
   names(us) <- names(x)
   us[which(x > 0)] <- -100 / x[which(x > 0)]
   us[which(x > 1)] <- 100 * x[which(x > 1)]

--- a/R/odds.hk2us.R
+++ b/R/odds.hk2us.R
@@ -9,9 +9,8 @@
 #' @examples
 #' odds.hk2us(c(1.93,0.05))
 odds.hk2us <- function (x) {
-  us <- rep(NA_real_, length(x))
-  dim(us) <- dim(x)
-  names(us) <- names(x)
+  us <- x
+  us[] <- NA_real_
   us[which(x > 0)] <- -100 / x[which(x > 0)]
   us[which(x > 1)] <- 100 * x[which(x > 1)]
   us

--- a/R/odds.indo2dec.R
+++ b/R/odds.indo2dec.R
@@ -10,6 +10,7 @@
 #' odds.indo2dec(c(1.93,2.05))
 odds.indo2dec <- function (x) {
   dec <- rep(NA_real_, length(x))
+  dim(dec) <- dim(x)
   names(dec) <- names(x)
   dec[which(x <= -1)] <- -1 / x[which(x <= -1)] + 1
   dec[which(x >= 1)] <- x[which(x >= 1)] + 1

--- a/R/odds.indo2dec.R
+++ b/R/odds.indo2dec.R
@@ -10,6 +10,7 @@
 #' odds.indo2dec(c(1.93,2.05))
 odds.indo2dec <- function (x) {
   dec <- rep(NA_real_, length(x))
+  names(dec) <- names(x)
   dec[which(x <= -1)] <- -1 / x[which(x <= -1)] + 1
   dec[which(x >= 1)] <- x[which(x >= 1)] + 1
   dec

--- a/R/odds.indo2dec.R
+++ b/R/odds.indo2dec.R
@@ -9,9 +9,8 @@
 #' @examples
 #' odds.indo2dec(c(1.93,2.05))
 odds.indo2dec <- function (x) {
-  dec <- rep(NA_real_, length(x))
-  dim(dec) <- dim(x)
-  names(dec) <- names(x)
+  dec <- x
+  dec[] <- NA_real_
   dec[which(x <= -1)] <- -1 / x[which(x <= -1)] + 1
   dec[which(x >= 1)] <- x[which(x >= 1)] + 1
   dec

--- a/R/odds.indo2hk.R
+++ b/R/odds.indo2hk.R
@@ -9,9 +9,8 @@
 #' @examples
 #' odds.indo2hk(c(1.93,2.05))
 odds.indo2hk <- function (x) {
-  hk <- rep(NA_real_, length(x))
-  dim(hk) <- dim(x)
-  names(hk) <- names(x)
+  hk <- x
+  hk[] <- NA_real_
   hk[which(x <= -1)] <- -1 / x[which(x <= -1)]
   hk[which(x >= 1)] <- x[which(x >= 1)]
   hk

--- a/R/odds.indo2hk.R
+++ b/R/odds.indo2hk.R
@@ -10,6 +10,7 @@
 #' odds.indo2hk(c(1.93,2.05))
 odds.indo2hk <- function (x) {
   hk <- rep(NA_real_, length(x))
+  dim(hk) <- dim(x)
   names(hk) <- names(x)
   hk[which(x <= -1)] <- -1 / x[which(x <= -1)]
   hk[which(x >= 1)] <- x[which(x >= 1)]

--- a/R/odds.indo2hk.R
+++ b/R/odds.indo2hk.R
@@ -10,6 +10,7 @@
 #' odds.indo2hk(c(1.93,2.05))
 odds.indo2hk <- function (x) {
   hk <- rep(NA_real_, length(x))
+  names(hk) <- names(x)
   hk[which(x <= -1)] <- -1 / x[which(x <= -1)]
   hk[which(x >= 1)] <- x[which(x >= 1)]
   hk

--- a/R/odds.indo2malay.R
+++ b/R/odds.indo2malay.R
@@ -9,9 +9,8 @@
 #' @examples
 #' odds.indo2malay(c(1.93,2.05))
 odds.indo2malay <- function (x) {
-  malay <- rep(NA_real_, length(x))
-  dim(malay) <- dim(x)
-  names(malay) <- names(x)
+  malay <- x
+  malay[] <- NA_real_
   malay[which(x <= -1 | x >= 1)] <- -1 / x[which(x <= -1 | x >= 1)]
   malay
 }

--- a/R/odds.indo2malay.R
+++ b/R/odds.indo2malay.R
@@ -10,6 +10,7 @@
 #' odds.indo2malay(c(1.93,2.05))
 odds.indo2malay <- function (x) {
   malay <- rep(NA_real_, length(x))
+  names(malay) <- names(x)
   malay[which(x <= -1 | x >= 1)] <- -1 / x[which(x <= -1 | x >= 1)]
   malay
 }

--- a/R/odds.indo2malay.R
+++ b/R/odds.indo2malay.R
@@ -10,6 +10,7 @@
 #' odds.indo2malay(c(1.93,2.05))
 odds.indo2malay <- function (x) {
   malay <- rep(NA_real_, length(x))
+  dim(malay) <- dim(x)
   names(malay) <- names(x)
   malay[which(x <= -1 | x >= 1)] <- -1 / x[which(x <= -1 | x >= 1)]
   malay

--- a/R/odds.indo2prob.R
+++ b/R/odds.indo2prob.R
@@ -10,6 +10,7 @@
 #' odds.indo2hk(c(1.93,2.05))
 odds.indo2prob <- function(x) {
   prob <- rep(NA_real_, length(x))
+  names(prob) <- names(x)
   prob[which(x <= -1)] <- 1 + 1 / (x[which(x <= -1)] - 1)
   prob[which(x >= 1)] <- 1 / (1 + x[which(x >= 1)])
   prob

--- a/R/odds.indo2prob.R
+++ b/R/odds.indo2prob.R
@@ -10,6 +10,7 @@
 #' odds.indo2hk(c(1.93,2.05))
 odds.indo2prob <- function(x) {
   prob <- rep(NA_real_, length(x))
+  dim(prob) <- dim(x)
   names(prob) <- names(x)
   prob[which(x <= -1)] <- 1 + 1 / (x[which(x <= -1)] - 1)
   prob[which(x >= 1)] <- 1 / (1 + x[which(x >= 1)])

--- a/R/odds.indo2prob.R
+++ b/R/odds.indo2prob.R
@@ -9,9 +9,8 @@
 #' @examples
 #' odds.indo2hk(c(1.93,2.05))
 odds.indo2prob <- function(x) {
-  prob <- rep(NA_real_, length(x))
-  dim(prob) <- dim(x)
-  names(prob) <- names(x)
+  prob <- x
+  prob[] <- NA_real_
   prob[which(x <= -1)] <- 1 + 1 / (x[which(x <= -1)] - 1)
   prob[which(x >= 1)] <- 1 / (1 + x[which(x >= 1)])
   prob

--- a/R/odds.indo2us.R
+++ b/R/odds.indo2us.R
@@ -10,6 +10,7 @@
 #' odds.indo2us(c(1.93,2.05))
 odds.indo2us <- function (x) {
   us <- rep(NA_real_, length(x))
+  names(us) <- names(x)
   us[which(x <= -1 | x >= 1)] <- 100 * x[which(x <= -1 | x >= 1)]
   us
 }

--- a/R/odds.indo2us.R
+++ b/R/odds.indo2us.R
@@ -10,6 +10,7 @@
 #' odds.indo2us(c(1.93,2.05))
 odds.indo2us <- function (x) {
   us <- rep(NA_real_, length(x))
+  dim(us) <- dim(x)
   names(us) <- names(x)
   us[which(x <= -1 | x >= 1)] <- 100 * x[which(x <= -1 | x >= 1)]
   us

--- a/R/odds.indo2us.R
+++ b/R/odds.indo2us.R
@@ -9,9 +9,8 @@
 #' @examples
 #' odds.indo2us(c(1.93,2.05))
 odds.indo2us <- function (x) {
-  us <- rep(NA_real_, length(x))
-  dim(us) <- dim(x)
-  names(us) <- names(x)
+  us <- x
+  us[] <- NA_real_
   us[which(x <= -1 | x >= 1)] <- 100 * x[which(x <= -1 | x >= 1)]
   us
 }

--- a/R/odds.malay2dec.R
+++ b/R/odds.malay2dec.R
@@ -9,9 +9,8 @@
 #' @examples
 #' odds.malay2dec(c(0.5,-0.6))
 odds.malay2dec <- function (x) {
-  dec <- rep(NA_real_, length(x))
-  dim(dec) <- dim(x)
-  names(dec) <- names(x)
+  dec <- x
+  dec[] <- NA_real_
   dec[which(x > 0 & x <= 1)] <- x[which(x > 0 & x <= 1)] + 1
   dec[which(x >= -1 & x < 0)] <- -1 / x[which(x >= -1 & x < 0)] + 1
   dec

--- a/R/odds.malay2dec.R
+++ b/R/odds.malay2dec.R
@@ -10,6 +10,7 @@
 #' odds.malay2dec(c(0.5,-0.6))
 odds.malay2dec <- function (x) {
   dec <- rep(NA_real_, length(x))
+  dim(dec) <- dim(x)
   names(dec) <- names(x)
   dec[which(x > 0 & x <= 1)] <- x[which(x > 0 & x <= 1)] + 1
   dec[which(x >= -1 & x < 0)] <- -1 / x[which(x >= -1 & x < 0)] + 1

--- a/R/odds.malay2dec.R
+++ b/R/odds.malay2dec.R
@@ -10,6 +10,7 @@
 #' odds.malay2dec(c(0.5,-0.6))
 odds.malay2dec <- function (x) {
   dec <- rep(NA_real_, length(x))
+  names(dec) <- names(x)
   dec[which(x > 0 & x <= 1)] <- x[which(x > 0 & x <= 1)] + 1
   dec[which(x >= -1 & x < 0)] <- -1 / x[which(x >= -1 & x < 0)] + 1
   dec

--- a/R/odds.malay2hk.R
+++ b/R/odds.malay2hk.R
@@ -10,6 +10,7 @@
 #' odds.malay2hk(c(1.93,2.05))
 odds.malay2hk <- function (x) {
   hk <- rep(NA_real_, length(x))
+  names(hk) <- names(x)
   hk[which(x > 0 & x <= 1)] <- x[which(x > 0 & x <= 1)]
   hk[which(x >= -1 & x < 0)] <- -1 / x[which(x >= -1 & x < 0)]
   hk

--- a/R/odds.malay2hk.R
+++ b/R/odds.malay2hk.R
@@ -10,6 +10,7 @@
 #' odds.malay2hk(c(1.93,2.05))
 odds.malay2hk <- function (x) {
   hk <- rep(NA_real_, length(x))
+  dim(hk) <- dim(x)
   names(hk) <- names(x)
   hk[which(x > 0 & x <= 1)] <- x[which(x > 0 & x <= 1)]
   hk[which(x >= -1 & x < 0)] <- -1 / x[which(x >= -1 & x < 0)]

--- a/R/odds.malay2hk.R
+++ b/R/odds.malay2hk.R
@@ -9,9 +9,8 @@
 #' @examples
 #' odds.malay2hk(c(1.93,2.05))
 odds.malay2hk <- function (x) {
-  hk <- rep(NA_real_, length(x))
-  dim(hk) <- dim(x)
-  names(hk) <- names(x)
+  hk <- x
+  hk[] <- NA_real_
   hk[which(x > 0 & x <= 1)] <- x[which(x > 0 & x <= 1)]
   hk[which(x >= -1 & x < 0)] <- -1 / x[which(x >= -1 & x < 0)]
   hk

--- a/R/odds.malay2indo.R
+++ b/R/odds.malay2indo.R
@@ -10,6 +10,7 @@
 #' odds.malay2indo(c(1.93,2.05))
 odds.malay2indo <- function (x) {
   indo <- rep(NA_real_, length(x))
+  dim(indo) <- dim(x)
   names(indo) <- names(x)
   indo[which(x >= -1 & x != 0 & x <= 1)] <- -1 / x[which(x >= -1 & x != 0 & x <= 1)]
   indo

--- a/R/odds.malay2indo.R
+++ b/R/odds.malay2indo.R
@@ -10,6 +10,7 @@
 #' odds.malay2indo(c(1.93,2.05))
 odds.malay2indo <- function (x) {
   indo <- rep(NA_real_, length(x))
+  names(indo) <- names(x)
   indo[which(x >= -1 & x != 0 & x <= 1)] <- -1 / x[which(x >= -1 & x != 0 & x <= 1)]
   indo
 }

--- a/R/odds.malay2indo.R
+++ b/R/odds.malay2indo.R
@@ -9,9 +9,8 @@
 #' @examples
 #' odds.malay2indo(c(1.93,2.05))
 odds.malay2indo <- function (x) {
-  indo <- rep(NA_real_, length(x))
-  dim(indo) <- dim(x)
-  names(indo) <- names(x)
+  indo <- x
+  indo[] <- NA_real_
   indo[which(x >= -1 & x != 0 & x <= 1)] <- -1 / x[which(x >= -1 & x != 0 & x <= 1)]
   indo
 }

--- a/R/odds.malay2prob.R
+++ b/R/odds.malay2prob.R
@@ -10,6 +10,7 @@
 #' odds.malay2prob(c(1.93,2.05))
 odds.malay2prob <- function (x) {
   prob <- rep(NA_real_, length(x))
+  names(prob) <- names(x)
   prob[which(x > 0 & x <= 1)] <- 1 / (1 + x[which(x > 0 & x <= 1)])
   prob[which(x >= -1 & x < 0)] <- 1 / (1 - 1 / x[which(x >= -1 & x < 0)])
   prob

--- a/R/odds.malay2prob.R
+++ b/R/odds.malay2prob.R
@@ -10,6 +10,7 @@
 #' odds.malay2prob(c(1.93,2.05))
 odds.malay2prob <- function (x) {
   prob <- rep(NA_real_, length(x))
+  dim(prob) <- dim(x)
   names(prob) <- names(x)
   prob[which(x > 0 & x <= 1)] <- 1 / (1 + x[which(x > 0 & x <= 1)])
   prob[which(x >= -1 & x < 0)] <- 1 / (1 - 1 / x[which(x >= -1 & x < 0)])

--- a/R/odds.malay2prob.R
+++ b/R/odds.malay2prob.R
@@ -9,9 +9,8 @@
 #' @examples
 #' odds.malay2prob(c(1.93,2.05))
 odds.malay2prob <- function (x) {
-  prob <- rep(NA_real_, length(x))
-  dim(prob) <- dim(x)
-  names(prob) <- names(x)
+  prob <- x
+  prob[] <- NA_real_
   prob[which(x > 0 & x <= 1)] <- 1 / (1 + x[which(x > 0 & x <= 1)])
   prob[which(x >= -1 & x < 0)] <- 1 / (1 - 1 / x[which(x >= -1 & x < 0)])
   prob

--- a/R/odds.malay2us.R
+++ b/R/odds.malay2us.R
@@ -10,6 +10,7 @@
 #' odds.malay2us(c(0.5,-0.6))
 odds.malay2us <- function (x) {
   us <- rep(NA_real_, length(x))
+  dim(us) <- dim(x)
   names(us) <- names(x)
   us[which(x >= -1 & x != 0 & x <= 1)] <- -100 / x[which(x >= -1 & x != 0 & x <= 1)]
   us

--- a/R/odds.malay2us.R
+++ b/R/odds.malay2us.R
@@ -10,6 +10,7 @@
 #' odds.malay2us(c(0.5,-0.6))
 odds.malay2us <- function (x) {
   us <- rep(NA_real_, length(x))
+  names(us) <- names(x)
   us[which(x >= -1 & x != 0 & x <= 1)] <- -100 / x[which(x >= -1 & x != 0 & x <= 1)]
   us
 }

--- a/R/odds.malay2us.R
+++ b/R/odds.malay2us.R
@@ -9,9 +9,8 @@
 #' @examples
 #' odds.malay2us(c(0.5,-0.6))
 odds.malay2us <- function (x) {
-  us <- rep(NA_real_, length(x))
-  dim(us) <- dim(x)
-  names(us) <- names(x)
+  us <- x
+  us[] <- NA_real_
   us[which(x >= -1 & x != 0 & x <= 1)] <- -100 / x[which(x >= -1 & x != 0 & x <= 1)]
   us
 }

--- a/R/odds.prob2dec.R
+++ b/R/odds.prob2dec.R
@@ -10,6 +10,7 @@
 #' odds.prob2dec(c(0.5,0.6))
 odds.prob2dec <- function (x) {
   dec <- rep(NA_real_, length(x))
+  names(dec) <- names(x)
   dec[which(x > 0 & x < 1)] <- 1 / x[which(x > 0 & x < 1)]
   dec
 }

--- a/R/odds.prob2dec.R
+++ b/R/odds.prob2dec.R
@@ -10,6 +10,7 @@
 #' odds.prob2dec(c(0.5,0.6))
 odds.prob2dec <- function (x) {
   dec <- rep(NA_real_, length(x))
+  dim(dec) <- dim(x)
   names(dec) <- names(x)
   dec[which(x > 0 & x < 1)] <- 1 / x[which(x > 0 & x < 1)]
   dec

--- a/R/odds.prob2dec.R
+++ b/R/odds.prob2dec.R
@@ -9,9 +9,8 @@
 #' @examples
 #' odds.prob2dec(c(0.5,0.6))
 odds.prob2dec <- function (x) {
-  dec <- rep(NA_real_, length(x))
-  dim(dec) <- dim(x)
-  names(dec) <- names(x)
+  dec <- x
+  dec[] <- NA_real_
   dec[which(x > 0 & x < 1)] <- 1 / x[which(x > 0 & x < 1)]
   dec
 }

--- a/R/odds.prob2hk.R
+++ b/R/odds.prob2hk.R
@@ -10,6 +10,7 @@
 #' odds.prob2hk(c(0.5,0.6))
 odds.prob2hk <- function (x) {
   hk <- rep(NA_real_, length(x))
+  names(hk) <- names(x)
   hk[which(x > 0 & x < 1)] <- 1 / x[which(x > 0 & x < 1)] - 1
   hk
 }

--- a/R/odds.prob2hk.R
+++ b/R/odds.prob2hk.R
@@ -10,6 +10,7 @@
 #' odds.prob2hk(c(0.5,0.6))
 odds.prob2hk <- function (x) {
   hk <- rep(NA_real_, length(x))
+  dim(hk) <- dim(x)
   names(hk) <- names(x)
   hk[which(x > 0 & x < 1)] <- 1 / x[which(x > 0 & x < 1)] - 1
   hk

--- a/R/odds.prob2hk.R
+++ b/R/odds.prob2hk.R
@@ -9,9 +9,8 @@
 #' @examples
 #' odds.prob2hk(c(0.5,0.6))
 odds.prob2hk <- function (x) {
-  hk <- rep(NA_real_, length(x))
-  dim(hk) <- dim(x)
-  names(hk) <- names(x)
+  hk <- x
+  hk[] <- NA_real_
   hk[which(x > 0 & x < 1)] <- 1 / x[which(x > 0 & x < 1)] - 1
   hk
 }

--- a/R/odds.prob2indo.R
+++ b/R/odds.prob2indo.R
@@ -9,9 +9,8 @@
 #' @examples
 #' odds.prob2indo(c(0.5,0.6))
 odds.prob2indo <- function (x) {
-  indo <- rep(NA_real_, length(x))
-  dim(indo) <- dim(x)
-  names(indo) <- names(x)
+  indo <- x
+  indo[] <- NA_real_
   indo[which(x > 0 & x < 1)] <- 1 / x[which(x > 0 & x < 1)] - 1
   indo[which(x > 0.5 & x < 1)] <- 1 / (1 - 1 / x[which(x > 0.5 & x < 1)])
   indo

--- a/R/odds.prob2indo.R
+++ b/R/odds.prob2indo.R
@@ -10,6 +10,7 @@
 #' odds.prob2indo(c(0.5,0.6))
 odds.prob2indo <- function (x) {
   indo <- rep(NA_real_, length(x))
+  dim(indo) <- dim(x)
   names(indo) <- names(x)
   indo[which(x > 0 & x < 1)] <- 1 / x[which(x > 0 & x < 1)] - 1
   indo[which(x > 0.5 & x < 1)] <- 1 / (1 - 1 / x[which(x > 0.5 & x < 1)])

--- a/R/odds.prob2indo.R
+++ b/R/odds.prob2indo.R
@@ -10,6 +10,7 @@
 #' odds.prob2indo(c(0.5,0.6))
 odds.prob2indo <- function (x) {
   indo <- rep(NA_real_, length(x))
+  names(indo) <- names(x)
   indo[which(x > 0 & x < 1)] <- 1 / x[which(x > 0 & x < 1)] - 1
   indo[which(x > 0.5 & x < 1)] <- 1 / (1 - 1 / x[which(x > 0.5 & x < 1)])
   indo

--- a/R/odds.prob2malay.R
+++ b/R/odds.prob2malay.R
@@ -10,6 +10,7 @@
 #' odds.prob2malay(c(0.5,0.6))
 odds.prob2malay <- function (x) {
   malay <- rep(NA_real_, length(x))
+  names(malay) <- names(x)
   malay[which(x > 0 & x < 1)] <- 1 / (1 - 1 / x[which(x > 0 & x < 1)])
   malay[which(x > 0.5 & x < 1)] <- 1 / x[which(x > 0.5 & x < 1)] - 1
   malay

--- a/R/odds.prob2malay.R
+++ b/R/odds.prob2malay.R
@@ -9,9 +9,8 @@
 #' @examples
 #' odds.prob2malay(c(0.5,0.6))
 odds.prob2malay <- function (x) {
-  malay <- rep(NA_real_, length(x))
-  dim(malay) <- dim(x)
-  names(malay) <- names(x)
+  malay <- x
+  malay[] <- NA_real_
   malay[which(x > 0 & x < 1)] <- 1 / (1 - 1 / x[which(x > 0 & x < 1)])
   malay[which(x > 0.5 & x < 1)] <- 1 / x[which(x > 0.5 & x < 1)] - 1
   malay

--- a/R/odds.prob2malay.R
+++ b/R/odds.prob2malay.R
@@ -10,6 +10,7 @@
 #' odds.prob2malay(c(0.5,0.6))
 odds.prob2malay <- function (x) {
   malay <- rep(NA_real_, length(x))
+  dim(malay) <- dim(x)
   names(malay) <- names(x)
   malay[which(x > 0 & x < 1)] <- 1 / (1 - 1 / x[which(x > 0 & x < 1)])
   malay[which(x > 0.5 & x < 1)] <- 1 / x[which(x > 0.5 & x < 1)] - 1

--- a/R/odds.prob2us.R
+++ b/R/odds.prob2us.R
@@ -9,9 +9,8 @@
 #' @examples
 #' odds.prob2us(c(0.5,0.6))
 odds.prob2us <- function (x) {
-  us <- rep(NA_real_, length(x))
-  dim(us) <- dim(x)
-  names(us) <- names(x)
+  us <- x
+  us[] <- NA_real_
   us[which(x > 0 & x < 1)] <- 100 * (1 / x[which(x > 0 & x < 1)] - 1)
   us[which(x > 0.5 & x < 1)] <- 100 / (1 - 1 / x[which(x > 0.5 & x < 1)])
   us

--- a/R/odds.prob2us.R
+++ b/R/odds.prob2us.R
@@ -10,6 +10,7 @@
 #' odds.prob2us(c(0.5,0.6))
 odds.prob2us <- function (x) {
   us <- rep(NA_real_, length(x))
+  names(us) <- names(x)
   us[which(x > 0 & x < 1)] <- 100 * (1 / x[which(x > 0 & x < 1)] - 1)
   us[which(x > 0.5 & x < 1)] <- 100 / (1 - 1 / x[which(x > 0.5 & x < 1)])
   us

--- a/R/odds.prob2us.R
+++ b/R/odds.prob2us.R
@@ -10,6 +10,7 @@
 #' odds.prob2us(c(0.5,0.6))
 odds.prob2us <- function (x) {
   us <- rep(NA_real_, length(x))
+  dim(us) <- dim(x)
   names(us) <- names(x)
   us[which(x > 0 & x < 1)] <- 100 * (1 / x[which(x > 0 & x < 1)] - 1)
   us[which(x > 0.5 & x < 1)] <- 100 / (1 - 1 / x[which(x > 0.5 & x < 1)])

--- a/R/odds.us2dec.R
+++ b/R/odds.us2dec.R
@@ -10,6 +10,7 @@
 #' odds.us2dec(c(-200,150))
 odds.us2dec <- function (x) {
   dec <- rep(NA_real_, length(x))
+  names(dec) <- names(x)
   dec[which(x <= -100)] <- -100 / x[which(x <= -100)] + 1
   dec[which(x >= 100)] <- x[which(x >= 100)] / 100 + 1
   dec

--- a/R/odds.us2dec.R
+++ b/R/odds.us2dec.R
@@ -10,6 +10,7 @@
 #' odds.us2dec(c(-200,150))
 odds.us2dec <- function (x) {
   dec <- rep(NA_real_, length(x))
+  dim(dec) <- dim(x)
   names(dec) <- names(x)
   dec[which(x <= -100)] <- -100 / x[which(x <= -100)] + 1
   dec[which(x >= 100)] <- x[which(x >= 100)] / 100 + 1

--- a/R/odds.us2dec.R
+++ b/R/odds.us2dec.R
@@ -9,9 +9,8 @@
 #' @examples
 #' odds.us2dec(c(-200,150))
 odds.us2dec <- function (x) {
-  dec <- rep(NA_real_, length(x))
-  dim(dec) <- dim(x)
-  names(dec) <- names(x)
+  dec <- x
+  dec[] <- NA_real_
   dec[which(x <= -100)] <- -100 / x[which(x <= -100)] + 1
   dec[which(x >= 100)] <- x[which(x >= 100)] / 100 + 1
   dec

--- a/R/odds.us2hk.R
+++ b/R/odds.us2hk.R
@@ -10,6 +10,7 @@
 #' odds.us2hk(c(-200,150))
 odds.us2hk <- function (x){
   hk <- rep(NA_real_, length(x))
+  dim(hk) <- dim(x)
   names(hk) <- names(x)
   hk[which(x <= -100)] <- -100 / x[which(x <= -100)]
   hk[which(x >= 100)] <- x[which(x >= 100)] / 100

--- a/R/odds.us2hk.R
+++ b/R/odds.us2hk.R
@@ -9,9 +9,8 @@
 #' @examples
 #' odds.us2hk(c(-200,150))
 odds.us2hk <- function (x){
-  hk <- rep(NA_real_, length(x))
-  dim(hk) <- dim(x)
-  names(hk) <- names(x)
+  hk <- x
+  hk[] <- NA_real_
   hk[which(x <= -100)] <- -100 / x[which(x <= -100)]
   hk[which(x >= 100)] <- x[which(x >= 100)] / 100
   hk

--- a/R/odds.us2hk.R
+++ b/R/odds.us2hk.R
@@ -10,6 +10,7 @@
 #' odds.us2hk(c(-200,150))
 odds.us2hk <- function (x){
   hk <- rep(NA_real_, length(x))
+  names(hk) <- names(x)
   hk[which(x <= -100)] <- -100 / x[which(x <= -100)]
   hk[which(x >= 100)] <- x[which(x >= 100)] / 100
   hk

--- a/R/odds.us2indo.R
+++ b/R/odds.us2indo.R
@@ -9,9 +9,8 @@
 #' @examples
 #' odds.us2indo(c(-200,150))
 odds.us2indo <- function (x) {
-  indo <- rep(NA_real_, length(x))
-  dim(indo) <- dim(x)
-  names(indo) <- names(x)
+  indo <- x
+  indo[] <- NA_real_
   indo[which(x <= -100 | x >= 100)] <- x[which(x <= -100 | x >= 100)] / 100
   indo
 }

--- a/R/odds.us2indo.R
+++ b/R/odds.us2indo.R
@@ -10,6 +10,7 @@
 #' odds.us2indo(c(-200,150))
 odds.us2indo <- function (x) {
   indo <- rep(NA_real_, length(x))
+  dim(indo) <- dim(x)
   names(indo) <- names(x)
   indo[which(x <= -100 | x >= 100)] <- x[which(x <= -100 | x >= 100)] / 100
   indo

--- a/R/odds.us2indo.R
+++ b/R/odds.us2indo.R
@@ -10,6 +10,7 @@
 #' odds.us2indo(c(-200,150))
 odds.us2indo <- function (x) {
   indo <- rep(NA_real_, length(x))
+  names(indo) <- names(x)
   indo[which(x <= -100 | x >= 100)] <- x[which(x <= -100 | x >= 100)] / 100
   indo
 }

--- a/R/odds.us2malay.R
+++ b/R/odds.us2malay.R
@@ -10,6 +10,7 @@
 #' odds.us2malay(c(-200,150))
 odds.us2malay <- function (x) {
   malay <- rep(NA_real_, length(x))
+  dim(malay) <- dim(x)
   names(malay) <- names(x)
   malay[which(x <= -100 | x >= 100)] <- -100 / x[which(x <= -100 | x >= 100)]
   malay

--- a/R/odds.us2malay.R
+++ b/R/odds.us2malay.R
@@ -9,9 +9,8 @@
 #' @examples
 #' odds.us2malay(c(-200,150))
 odds.us2malay <- function (x) {
-  malay <- rep(NA_real_, length(x))
-  dim(malay) <- dim(x)
-  names(malay) <- names(x)
+  malay <- x
+  malay[] <- NA_real_
   malay[which(x <= -100 | x >= 100)] <- -100 / x[which(x <= -100 | x >= 100)]
   malay
 }

--- a/R/odds.us2malay.R
+++ b/R/odds.us2malay.R
@@ -10,6 +10,7 @@
 #' odds.us2malay(c(-200,150))
 odds.us2malay <- function (x) {
   malay <- rep(NA_real_, length(x))
+  names(malay) <- names(x)
   malay[which(x <= -100 | x >= 100)] <- -100 / x[which(x <= -100 | x >= 100)]
   malay
 }

--- a/R/odds.us2prob.R
+++ b/R/odds.us2prob.R
@@ -9,9 +9,8 @@
 #' @examples
 #' odds.us2prob(c(-200,150))
 odds.us2prob <- function (x) {
-  prob <- rep(NA_real_, length(x))
-  dim(prob) <- dim(x)
-  names(prob) <- names(x)
+  prob <- x
+  prob[] <- NA_real_
   prob[which(x <= -100)] <- 1 / (1 - 100 / x[which(x <= -100)])
   prob[which(x >= 100)] <- 1 / (1 + x[which(x >= 100)] / 100)
   prob

--- a/R/odds.us2prob.R
+++ b/R/odds.us2prob.R
@@ -10,6 +10,7 @@
 #' odds.us2prob(c(-200,150))
 odds.us2prob <- function (x) {
   prob <- rep(NA_real_, length(x))
+  names(prob) <- names(x)
   prob[which(x <= -100)] <- 1 / (1 - 100 / x[which(x <= -100)])
   prob[which(x >= 100)] <- 1 / (1 + x[which(x >= 100)] / 100)
   prob

--- a/R/odds.us2prob.R
+++ b/R/odds.us2prob.R
@@ -10,6 +10,7 @@
 #' odds.us2prob(c(-200,150))
 odds.us2prob <- function (x) {
   prob <- rep(NA_real_, length(x))
+  dim(prob) <- dim(x)
   names(prob) <- names(x)
   prob[which(x <= -100)] <- 1 / (1 - 100 / x[which(x <= -100)])
   prob[which(x >= 100)] <- 1 / (1 + x[which(x >= 100)] / 100)


### PR DESCRIPTION
If a named vector is input, the names will be maintained.
In odds.fv, matrix input is allowed to these functions, so this change maintains those dimensions.